### PR TITLE
Add ObjectId.id_for/2, which implements the default version of jgit's…

### DIFF
--- a/lib/xgit/lib/object_id.ex
+++ b/lib/xgit/lib/object_id.ex
@@ -7,6 +7,8 @@ defmodule Xgit.Lib.ObjectId do
   mechanisms for manipulating and validating such strings.
   """
 
+  alias Xgit.Lib.Constants
+
   @type t :: String.t()
 
   @doc ~S"""
@@ -30,5 +32,26 @@ defmodule Xgit.Lib.ObjectId do
     |> Enum.take(20)
     |> :erlang.list_to_binary()
     |> Base.encode16(case: :lower)
+  end
+
+  @doc ~S"""
+  Compute the git "name" of an object.
+
+  `obj_type` is the type of the object. Must be one of the `obj_*()` values from
+  `Xgit.Lib.Constants`.
+  """
+  def id_for(obj_type, data) when is_integer(obj_type) and is_list(data) do
+    # FYI :sha in Erlang parlance == SHA-1.
+
+    :sha
+    |> :crypto.hash_init()
+    |> :crypto.hash_update(Constants.encoded_type_string(obj_type))
+    |> :crypto.hash_update(' ')
+    |> :crypto.hash_update('#{Enum.count(data)}')
+    |> :crypto.hash_update([0])
+    |> :crypto.hash_update(data)
+    |> :crypto.hash_final()
+    |> Base.encode16()
+    |> String.downcase()
   end
 end

--- a/test/xgit/lib/object_id_test.exs
+++ b/test/xgit/lib/object_id_test.exs
@@ -1,7 +1,9 @@
 defmodule Xgit.Lib.ObjectIdTest do
   use ExUnit.Case, async: true
 
+  alias Xgit.Lib.Constants
   alias Xgit.Lib.ObjectId
+
   doctest Xgit.Lib.ObjectId
 
   test "zero/0" do
@@ -26,5 +28,12 @@ defmodule Xgit.Lib.ObjectIdTest do
 
     assert 1..25 |> Enum.to_list() |> ObjectId.from_raw_bytes() ==
              "0102030405060708090a0b0c0d0e0f1011121314"
+  end
+
+  test "id_for/2" do
+    data = 'test025 some data, more than 16 bytes to get good coverage'
+
+    assert ObjectId.id_for(Constants.obj_blob(), data) ==
+             "4f561df5ecf0dfbd53a0dc0f37262fef075d9dde"
   end
 end


### PR DESCRIPTION
… ObjectInserter.idFor in the (common) case where we don't otherwise need to create an ObjectInserter.