### PR TITLE
Let's not implement check_path on SystemReader.

### DIFF
--- a/lib/xgit/util/system_reader.ex
+++ b/lib/xgit/util/system_reader.ex
@@ -207,18 +207,9 @@ defprotocol Xgit.Util.SystemReader do
   # 	return isMacOS.booleanValue();
   # }
 
-  # /**
-  #  * Check tree path entry for validity.
-  #  * <p>
-  #  * Scans a multi-directory path string such as {@code "src/main.c"}.
-  #  *
-  #  * @param path path string to scan.
-  #  * @throws org.eclipse.jgit.errors.CorruptObjectException path is invalid.
-  #  * @since 3.6
-  #  */
-  # public void checkPath(String path) throws CorruptObjectException {
-  # 	platformChecker.checkPath(path);
-  # }
+  # PORTING NOTE: We do not implement check_path in SystemReader.
+  # Callers should instead create an instance of ObjectReader and call
+  # check_path_segment on that instance intead.
 end
 
 defimpl Xgit.Util.SystemReader, for: Any do


### PR DESCRIPTION
## Changes in This Pull Request
I've decided not to implement `check_path` on `SystemReader`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [ ] ~There is test coverage for all changes.~ _n/a_
- [ ] ~Any code ported from jgit maintains all existing copyright notices.~ _n/a_
- [ ] ~The Eclipse Distribution License header text is included in all new source files.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
