### PR TITLE
Implement ObjectChecker.check_path/2.

### DIFF
--- a/lib/xgit/util/system_reader.ex
+++ b/lib/xgit/util/system_reader.ex
@@ -209,7 +209,7 @@ defprotocol Xgit.Util.SystemReader do
 
   # PORTING NOTE: We do not implement check_path in SystemReader.
   # Callers should instead create an instance of ObjectReader and call
-  # check_path_segment on that instance intead.
+  # check_path/2 using that instance intead.
 end
 
 defimpl Xgit.Util.SystemReader, for: Any do

--- a/test/xgit/lib/object_checker_test.exs
+++ b/test/xgit/lib/object_checker_test.exs
@@ -1401,6 +1401,29 @@ defmodule Xgit.Lib.ObjectCheckerTest do
     end
   end
 
+  test "check_path/2" do
+    assert valid_path?("a")
+    assert valid_path?("a/b")
+    assert valid_path?("ab/cd/ef")
+
+    refute valid_path?("")
+    refute valid_path?("/a")
+    refute valid_path?("a//b")
+    refute valid_path?("ab/cd//ef")
+    refute valid_path?("a/")
+    refute valid_path?("ab/cd/ef/")
+    refute valid_path?("a\u0000b")
+  end
+
+  defp valid_path?(path) do
+    try do
+      ObjectChecker.check_path!(%ObjectChecker{}, path)
+      true
+    rescue
+      _ -> false
+    end
+  end
+
   describe "check_path_segment/2" do
     test "bug 477090" do
       checker = %ObjectChecker{macosx?: true}


### PR DESCRIPTION
Closes #131.

## Changes in This Pull Request
Implement `ObjectChecker.check_path/2`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] Any code ported from jgit maintains all existing copyright notices.
- [ ] ~The Eclipse Distribution License header text is included in all new source files.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
