### PR TITLE
Looks like we don't really need RevFlag and RevFlagSet.

### DIFF
--- a/lib/xgit/revwalk/README.md
+++ b/lib/xgit/revwalk/README.md
@@ -1,0 +1,10 @@
+# Porting Notes for RevWalk
+
+## Simplifications Taken
+
+Some jgit classes from this package were deemed unnecessary in the Erlang/Elixir environment.
+
+Specifically:
+
+* `RevFlag`: translates neatly to an atom
+* `RevFlagSet`: translates to a `MapSet` of atoms

--- a/notes/porting_roadmap.txt
+++ b/notes/porting_roadmap.txt
@@ -11,8 +11,6 @@ RevWalk
   RevBlob
   RevCommit
   RevFilter
-  RevFlag
-  RevFlagSet
   RevObject
   RevTag DEFER?
   RevTree
@@ -24,7 +22,6 @@ RevWalk
 
 AbstractRevQueue
   RevCommit
-  RevFlag
 
 AbstractTreeIterator
   AttributesNode DEFER?
@@ -74,7 +71,6 @@ ObjectWalk
   ObjectInserter DEFER?
   RevBlob
   RevCommit
-  RevFlag
   RevObject
   RevTree
   RevWalk
@@ -102,16 +98,7 @@ RevFilter ABSTRACT
   RevCommit
   RevWalk
 
-RevFlag
-  RevWalk
-
-RevFlagSet
-  RevFlag
-  RevWalkTestCase
-
 RevObject ABSTRACT
-  RevFlag
-  RevFlagSet
   RevWalk
 
 RevQueueTestCase


### PR DESCRIPTION

## Changes in This Pull Request
Looks like we don't really need to port `RevFlag` and `RevFlagSet`.

Document as such in porting roadmap.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [ ] ~There is test coverage for all changes.~ _n/a_
- [ ] ~Any code ported from jgit maintains all existing copyright notices.~ _n/a_
- [ ] ~The Eclipse Distribution License header text is included in all new source files.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
