### PR TITLE
Add a comment about FileObjectDatabase being folded into ObjectDirectory …

### DIFF
--- a/lib/xgit/internal/storage/file/file_object_directory.ex
+++ b/lib/xgit/internal/storage/file/file_object_directory.ex
@@ -1,0 +1,2 @@
+# PORTING NOTE: The FileObjectDirectory class from jgit was folded into
+# the ObjectDirectory module in Xgit.

--- a/lib/xgit/internal/storage/file/object_directory.ex
+++ b/lib/xgit/internal/storage/file/object_directory.ex
@@ -1,7 +1,8 @@
 # Copyright (C) 2009, Google Inc.
 # and other copyright owners as documented in the project's IP log.
 #
-# Elixir adaptation from jgit file:
+# Elixir adaptation from jgit files:
+# org.eclipse.jgit/src/org/eclipse/jgit/internal/storage/file/FileObjectDatabase.java
 # org.eclipse.jgit/src/org/eclipse/jgit/internal/storage/file/ObjectDirectory.java
 #
 # Copyright (C) 2019, Eric Scouten <eric+xgit@scouten.com>
@@ -62,6 +63,8 @@ defmodule Xgit.Internal.Storage.File.ObjectDirectory do
   searched (recursively through all alternates) before the slow half is
   considered.
   """
+
+  # PORTING NOTE: The abstract class FileObjectDatabase is merged into this module.
 
   # TO DO: See if CachedObjectDirectory can be folded into this implementation.
 


### PR DESCRIPTION
… since I just spent an inordinate amount of time reconstructing that information for myself. :-O

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [ ] ~There is test coverage for all changes.~ _n/a_
- [ ] ~Any code ported from jgit maintains all existing copyright notices.~ _n/a_
- [ ] ~The Eclipse Distribution License header text is included in all new source files.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
