### PR TITLE
Make Xgit.Storage.File.FileSnapshot a public module.

### DIFF
--- a/lib/xgit/dir_cache.ex
+++ b/lib/xgit/dir_cache.ex
@@ -62,8 +62,8 @@ defmodule Xgit.DirCache do
   use GenServer
 
   # alias Xgit.Errors.IndexReadError
-  # alias Xgit.Internal.Storage.File.FileSnapshot
   alias Xgit.Lib.Repository
+  # alias Xgit.Storage.File.FileSnapshot
   alias Xgit.Util.GenServerUtils
 
   # TO DO: Finish porting this module. https://github.com/elixir-git/xgit/issues/164

--- a/lib/xgit/storage/file/file_based_config.ex
+++ b/lib/xgit/storage/file/file_based_config.ex
@@ -57,13 +57,13 @@ defmodule Xgit.Storage.File.FileBasedConfig do
 
   Struct members:
   * `path`: Path to the config file.
-  * `snapshot`: An `Xgit.Internal.Storage.File.FileSnapshot` for this path.
+  * `snapshot`: An `Xgit.Storage.File.FileSnapshot` for this path.
   """
   @enforce_keys [:path, :snapshot]
   defstruct [:path, :snapshot]
 
-  alias Xgit.Internal.Storage.File.FileSnapshot
   alias Xgit.Lib.Config
+  alias Xgit.Storage.File.FileSnapshot
 
   @doc ~S"""
   Create a configuration for a file path with no default fallback.

--- a/lib/xgit/storage/file/file_snapshot.ex
+++ b/lib/xgit/storage/file/file_snapshot.ex
@@ -44,7 +44,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-defmodule Xgit.Internal.Storage.File.FileSnapshot do
+defmodule Xgit.Storage.File.FileSnapshot do
   @moduledoc ~S"""
   Caches when a file was last read, making it possible to detect future edits.
 
@@ -185,7 +185,7 @@ defmodule Xgit.Internal.Storage.File.FileSnapshot do
     do: ConCache.put(:xgit_file_snapshot, ref, time)
 
   defimpl String.Chars do
-    alias Xgit.Internal.Storage.File.FileSnapshot
+    alias Xgit.Storage.File.FileSnapshot
 
     def to_string(%FileSnapshot{last_modified: :dirty}), do: "DIRTY"
 

--- a/test/xgit/storage/file/file_snapshot_test.exs
+++ b/test/xgit/storage/file/file_snapshot_test.exs
@@ -44,10 +44,10 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-defmodule Xgit.Internal.Storage.File.FileSnapshotTest do
+defmodule Xgit.Storage.File.FileSnapshotTest do
   use ExUnit.Case, async: true
 
-  alias Xgit.Internal.Storage.File.FileSnapshot
+  alias Xgit.Storage.File.FileSnapshot
 
   setup do
     Temp.track!()


### PR DESCRIPTION
(Remove Internal prefix from module name.)

## Changes in This Pull Request
`FileSnapshot` gets referred to in documentation (see #175, in progress). Make it public.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [ ] ~There is test coverage for all changes.~ _n/a_
- [ ] ~Any code ported from jgit maintains all existing copyright notices.~ _n/a_
- [ ] ~The Eclipse Distribution License header text is included in all new source files.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
