### PR TITLE
Implement most of Xgit.RevWalk.RevBlob.

### DIFF
--- a/lib/xgit/revwalk/rev_blob.ex
+++ b/lib/xgit/revwalk/rev_blob.ex
@@ -1,0 +1,109 @@
+# Copyright (C) 2009, Google Inc.
+# Copyright (C) 2008, Marek Zawirski <marek.zawirski@gmail.com>
+# Copyright (C) 2008, Shawn O. Pearce <spearce@spearce.org>
+# and other copyright owners as documented in the project's IP log.
+#
+# Elixir adaptation from jgit file:
+# org.eclipse.jgit/src/org/eclipse/jgit/revwalk/RevBlob.java
+#
+# Copyright (C) 2019, Eric Scouten <eric+xgit@scouten.com>
+#
+# This program and the accompanying materials are made available
+# under the terms of the Eclipse Distribution License v1.0 which
+# accompanies this distribution, is reproduced below, and is
+# available at http://www.eclipse.org/org/documents/edl-v10.php
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or
+# without modification, are permitted provided that the following
+# conditions are met:
+#
+# - Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# - Redistributions in binary form must reproduce the above
+#   copyright notice, this list of conditions and the following
+#   disclaimer in the documentation and/or other materials provided
+#   with the distribution.
+#
+# - Neither the name of the Eclipse Foundation, Inc. nor the
+#   names of its contributors may be used to endorse or promote
+#   products derived from this software without specific prior
+#   written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+defmodule Xgit.RevWalk.RevBlob do
+  @moduledoc ~S"""
+  Represents a binary file or a symbolic link.
+  """
+
+  @typedoc ~S"""
+  Implements `Xgit.RevWalk.RevObject.Object` for a binary file or symbolic link.
+
+  ## Struct Members
+
+  * `flags`: (`MapSet`) flags associated with this object
+  * `id`: (string) object ID
+  """
+  @type t :: %__MODULE__{flags: MapSet.t(), id: String.t()}
+
+  @enforce_keys [:id]
+  defstruct [{:flags, MapSet.new()}, :id]
+
+  defimpl Xgit.RevWalk.RevObject.Object do
+    alias Xgit.Lib.Constants
+
+    @impl true
+    def object_id(%{id: id}), do: id
+
+    @impl true
+    def parsed?(%{flags: %MapSet{} = flags}), do: MapSet.member?(flags, :parsed)
+
+    @impl true
+    def type(_), do: Constants.obj_blob()
+
+    @impl true
+    def flags(%{flags: %MapSet{} = flags}), do: flags
+
+    @impl true
+    def add_flags(%{flags: %MapSet{} = flags} = object, %MapSet{} = new_flags),
+      do: %{object | flags: MapSet.union(flags, new_flags)}
+
+    @impl true
+    def remove_flags(%{flags: %MapSet{} = flags} = object, %MapSet{} = new_flags),
+      do: %{object | flags: MapSet.difference(flags, new_flags)}
+
+    # TO DO: Finish implementation of RevObject and related modules.
+    # https://github.com/elixir-git/xgit/issues/181
+
+    # @Override
+    # void parseHeaders(RevWalk walk) throws MissingObjectException,
+    #     IncorrectObjectTypeException, IOException {
+    #   if (walk.reader.has(this))
+    #     flags |= PARSED;
+    #   else
+    #     throw new MissingObjectException(this, getType());
+    # }
+    #
+    # @Override
+    # void parseBody(RevWalk walk) throws MissingObjectException,
+    #     IncorrectObjectTypeException, IOException {
+    #   if ((flags & PARSED) == 0)
+    #     parseHeaders(walk);
+    # }
+  end
+end

--- a/lib/xgit/revwalk/rev_blob.ex
+++ b/lib/xgit/revwalk/rev_blob.ex
@@ -106,4 +106,9 @@ defmodule Xgit.RevWalk.RevBlob do
     #     parseHeaders(walk);
     # }
   end
+
+  defimpl String.Chars do
+    @impl true
+    defdelegate to_string(object), to: Xgit.RevWalk.RevObject
+  end
 end

--- a/lib/xgit/revwalk/rev_object.ex
+++ b/lib/xgit/revwalk/rev_object.ex
@@ -151,6 +151,9 @@ defmodule Xgit.RevWalk.RevObject do
     end
   end
 
+  # TO DO: Finish implementation of RevObject and related modules.
+  # https://github.com/elixir-git/xgit/issues/181
+
   # abstract void parseHeaders(RevWalk walk) throws MissingObjectException,
   #     IncorrectObjectTypeException, IOException;
   #

--- a/lib/xgit/revwalk/rev_object.ex
+++ b/lib/xgit/revwalk/rev_object.ex
@@ -175,6 +175,12 @@ defmodule Xgit.RevWalk.RevObject do
   defdelegate type(object), to: Object
 
   @doc ~S"""
+  Returns `true` if this object has been parsed.
+  """
+  @spec parsed?(object :: t) :: boolean
+  defdelegate parsed?(object), to: Object
+
+  @doc ~S"""
   Returns `true` if the given flag has been set on this object.
   """
   @spec has_flag?(object :: t, flag :: atom) :: boolean

--- a/notes/porting_roadmap.txt
+++ b/notes/porting_roadmap.txt
@@ -7,7 +7,6 @@ RevWalk
   FIFORevQueue
   ObjectIdOwnerMap
   ObjectWalk
-  RevBlob
   RevCommit
   RevFilter
   RevTag DEFER?
@@ -65,15 +64,11 @@ ObjectWalk
   Commit DEFER?
   ObjectFilter
   ObjectInserter DEFER?
-  RevBlob
   RevCommit
   RevTree
   RevWalk
   RevWalkTestCase CYCLE with RevWalk itself
   TreeFormatter DEFER?
-
-RevBlob
-  RevWalk
 
 RevCommit
   FIFORevQueue

--- a/test/xgit/revwalk/rev_blob_test.exs
+++ b/test/xgit/revwalk/rev_blob_test.exs
@@ -1,0 +1,174 @@
+# Copyright (C) 2019, Eric Scouten <eric+xgit@scouten.com>
+#
+# This program and the accompanying materials are made available
+# under the terms of the Eclipse Distribution License v1.0 which
+# accompanies this distribution, is reproduced below, and is
+# available at http://www.eclipse.org/org/documents/edl-v10.php
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or
+# without modification, are permitted provided that the following
+# conditions are met:
+#
+# - Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# - Redistributions in binary form must reproduce the above
+#   copyright notice, this list of conditions and the following
+#   disclaimer in the documentation and/or other materials provided
+#   with the distribution.
+#
+# - Neither the name of the Eclipse Foundation, Inc. nor the
+#   names of its contributors may be used to endorse or promote
+#   products derived from this software without specific prior
+#   written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+defmodule Xgit.RevWalk.RevBlobTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Lib.Constants
+  alias Xgit.RevWalk.RevBlob
+  alias Xgit.RevWalk.RevObject
+
+  @blob_id "5cd8074ac04156d8f3663b42a40ddcad7d2574b1"
+  @blob %RevBlob{id: @blob_id}
+
+  test "object_id/1" do
+    assert RevObject.object_id(@blob) == @blob_id
+  end
+
+  test "type/1" do
+    assert RevObject.type(@blob) == Constants.obj_blob()
+  end
+
+  describe "flags" do
+    @blob_with_flags %Xgit.RevWalk.RevBlob{
+      id: @blob_id,
+      flags: MapSet.new([:blah, :boop, :biff])
+    }
+
+    test "add_flag/2" do
+      refute RevObject.has_flag?(@blob, :blah)
+
+      with_blah = RevObject.add_flag(@blob, :blah)
+      assert RevObject.has_flag?(with_blah, :blah)
+    end
+
+    test "add_flags/2" do
+      refute RevObject.has_flag?(@blob, :blah)
+      refute RevObject.has_flag?(@blob, :boop)
+      refute RevObject.has_flag?(@blob, :biff)
+
+      with_flags = RevObject.add_flags(@blob, MapSet.new([:blah, :boop]))
+
+      assert RevObject.has_flag?(with_flags, :blah)
+      assert RevObject.has_flag?(with_flags, :boop)
+      refute RevObject.has_flag?(with_flags, :biff)
+    end
+
+    test "remove_flag/2" do
+      assert RevObject.has_flag?(@blob_with_flags, :blah)
+
+      without_blah = RevObject.remove_flag(@blob_with_flags, :blah)
+
+      refute RevObject.has_flag?(without_blah, :blah)
+      assert RevObject.has_flag?(without_blah, :boop)
+      assert RevObject.has_flag?(without_blah, :biff)
+    end
+
+    test "remove_flags/2" do
+      assert RevObject.has_flag?(@blob_with_flags, :blah)
+      assert RevObject.has_flag?(@blob_with_flags, :boop)
+      assert RevObject.has_flag?(@blob_with_flags, :biff)
+
+      without_flags = RevObject.remove_flags(@blob_with_flags, MapSet.new([:blah, :boop]))
+
+      refute RevObject.has_flag?(without_flags, :blah)
+      refute RevObject.has_flag?(without_flags, :boop)
+      assert RevObject.has_flag?(without_flags, :biff)
+    end
+
+    test "has_any_flag?/2" do
+      refute RevObject.has_any_flag?(@blob_with_flags, MapSet.new([:jaskdlf]))
+      assert RevObject.has_any_flag?(@blob_with_flags, MapSet.new([:jaskdlf, :blah]))
+    end
+
+    test "has_all_flags?/2" do
+      refute RevObject.has_all_flags?(@blob_with_flags, MapSet.new([:jaskdlf]))
+      refute RevObject.has_all_flags?(@blob_with_flags, MapSet.new([:jaskdlf, :blah]))
+      assert RevObject.has_all_flags?(@blob_with_flags, MapSet.new([:blah, :boop]))
+
+      assert RevObject.has_all_flags?(
+               @blob_with_flags,
+               MapSet.new([:blah, :boop, :biff])
+             )
+
+      refute RevObject.has_all_flags?(
+               @blob_with_flags,
+               MapSet.new([:blah, :boop, :biff, :more])
+             )
+    end
+
+    @parsed_blob %Xgit.RevWalk.RevBlob{id: @blob_id, flags: MapSet.new([:parsed])}
+
+    test "parsed?/1" do
+      assert RevObject.parsed?(@parsed_blob)
+      refute RevObject.parsed?(@blob)
+    end
+
+    test "to_string/1" do
+      assert to_string(@blob) == "blob #{@blob_id} ------"
+
+      b = RevObject.add_flag(@blob, :rewrite)
+      assert to_string(b) == "blob #{@blob_id} --r---"
+    end
+  end
+
+  # @SuppressWarnings("unlikely-arg-type")
+  # @Test
+  # public void testEquals() throws Exception {
+  #   final RevCommit a1 = commit();
+  #   final RevCommit b1 = commit();
+  #
+  #   assertTrue(a1.equals(a1));
+  #   assertTrue(a1.equals((Object) a1));
+  #   assertFalse(a1.equals(b1));
+  #
+  #   assertTrue(a1.equals(a1));
+  #   assertTrue(a1.equals((Object) a1));
+  #   assertFalse(a1.equals(""));
+  #
+  #   final RevCommit a2;
+  #   final RevCommit b2;
+  #   try (RevWalk rw2 = new RevWalk(db)) {
+  #     a2 = rw2.parseCommit(a1);
+  #     b2 = rw2.parseCommit(b1);
+  #   }
+  #   assertNotSame(a1, a2);
+  #   assertNotSame(b1, b2);
+  #
+  #   assertTrue(a1.equals(a2));
+  #   assertTrue(b1.equals(b2));
+  #
+  #   assertEquals(a1.hashCode(), a2.hashCode());
+  #   assertEquals(b1.hashCode(), b2.hashCode());
+  #
+  #   assertTrue(AnyObjectId.equals(a1, a2));
+  #   assertTrue(AnyObjectId.equals(b1, b2));
+  # }
+end


### PR DESCRIPTION
## Changes in This Pull Request
Wire up enough of `Xgit.RevWalk.RevBlob` that we can implement the `blob` function in `TestRepository`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] Any code ported from jgit maintains all existing copyright notices.
- [x] The Eclipse Distribution License header text is included in all new source files.
- [x] If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
