### PR TITLE
BUG: Config.get_boolean/5 didn't honor default value. Fixed.

### DIFF
--- a/lib/xgit/lib/config.ex
+++ b/lib/xgit/lib/config.ex
@@ -306,6 +306,7 @@ defmodule Xgit.Lib.Config do
 
   defp to_boolean(nil, _default), do: true
   defp to_boolean(:empty, _default), do: true
+  defp to_boolean(:missing, default), do: default
   defp to_boolean("false", _default), do: false
   defp to_boolean("no", _default), do: false
   defp to_boolean("off", _default), do: false

--- a/test/xgit/lib/config_test.exs
+++ b/test/xgit/lib/config_test.exs
@@ -318,6 +318,13 @@ defmodule Xgit.Lib.ConfigTest do
       assert Config.get_boolean(c, "s", "a", false) == true
       assert Config.get_boolean(c, "s", "b", true) == false
     end
+
+    test "defaults properly when value missing" do
+      c = parse("[s]\na =42\nb = 51\n")
+
+      assert Config.get_boolean(c, "s", "c", false) == false
+      assert Config.get_boolean(c, "s", "c", true) == true
+    end
   end
 
   test "read integer with g/m/k notation" do


### PR DESCRIPTION
## Changes in This Pull Request
Found a bug in `Config.get_boolean/5` (default value wasn't honored). Fixed it.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] ~All applicable changes have been documented.~ _n/a_
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright notices.~ _n/a_
- [ ] ~The Eclipse Distribution License header text is included in all new source files.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
