### PR TITLE
Discontinue the port from jgit to xgit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
+
+## ARCHIVED? WHAT?!?
+
+After careful consideration, I am setting aside this project for now. I am finding that porting from the jgit implementation is leading to an approach that is more complicated than I had hoped. Patterns that are appropriate in Java (complex object hierarchies, shared state across threads) do not translate well into the Erlang / OTP world.
+
+From the ashes of this effort, there arises a new one. I am currently working on a new version of the project which is a from-the-ground-up implementation of git in Elixir. That project will occasionally draw upon work done here, so all is not lost.
+
+I'm happy enough with the new effort to let it take on the mantle of being called [xgit](https://github.com/elixir-git/archived-jgit-port).
+
+I hope to see you there.
+
+What follows is the README before I undertook this decision:
+
+----
+
 # Xgit
 
-Pure Elixir native implementation of git [![Build Status](https://travis-ci.org/elixir-git/xgit.svg?branch=master)](https://travis-ci.org/elixir-git/xgit) [![Coverage Status](https://coveralls.io/repos/github/elixir-git/xgit/badge.svg?branch=master)](https://coveralls.io/github/elixir-git/xgit?branch=master)
-
+Pure Elixir native implementation of git [![Build Status](https://travis-ci.org/elixir-git/archived-jgit-port.svg?branch=master)](https://travis-ci.org/elixir-git/archived-jgit-port) [![Coverage Status](https://coveralls.io/repos/github/elixir-git/archived-jgit-port/badge.svg?branch=master)](https://coveralls.io/github/elixir-git/archived-jgit-port?branch=master)
 
 ## WORK IN PROGRESS
 
@@ -14,13 +28,13 @@ Pure Elixir native implementation of git [![Build Status](https://travis-ci.org/
 **The current major infrastructure being targeted is porting the jgit `RevWalk` class.** This provides core infrastructure for walking commit history and object graphs. Progress on this project is tracked as follows:
 
 * [Porting Roadmap](./notes/porting_roadmap.txt)
-* [GitHub project for porting `RevWalk`](https://github.com/elixir-git/xgit/projects/3)
+* [GitHub project for porting `RevWalk`](https://github.com/elixir-git/archived-jgit-port/projects/3)
 
 **There is also important work to be done in backfilling existing porting work.** Please see:
 
-* [Issues tagged "good first issue"](https://github.com/elixir-git/xgit/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-* [Issues tagged "help wanted"](https://github.com/elixir-git/xgit/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) _more issues, but potentially more challenging_
-* [Project "Backfill incomplete implementations"](https://github.com/elixir-git/xgit/projects/2)
+* [Issues tagged "good first issue"](https://github.com/elixir-git/archived-jgit-port/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+* [Issues tagged "help wanted"](https://github.com/elixir-git/archived-jgit-port/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) _more issues, but potentially more challenging_
+* [Project "Backfill incomplete implementations"](https://github.com/elixir-git/archived-jgit-port/projects/2)
 
 
 ## Why an All-Elixir Implementation?

--- a/lib/xgit/diff/content_source.ex
+++ b/lib/xgit/diff/content_source.ex
@@ -61,7 +61,7 @@ defmodule Xgit.Diff.ContentSource do
 
   @type t :: ObjectReader.t()
   # PORTING NOTE: add WorkingTreeIterator.t(), whenever that is defined.
-  # https://github.com/elixir-git/xgit/issues/124
+  # https://github.com/elixir-git/archived-jgit-port/issues/124
 
   @doc ~S"""
   Determine the size of the object.

--- a/lib/xgit/dir_cache.ex
+++ b/lib/xgit/dir_cache.ex
@@ -66,7 +66,7 @@ defmodule Xgit.DirCache do
   # alias Xgit.Storage.File.FileSnapshot
   alias Xgit.Util.GenServerUtils
 
-  # TO DO: Finish porting this module. https://github.com/elixir-git/xgit/issues/164
+  # TO DO: Finish porting this module. https://github.com/elixir-git/archived-jgit-port/issues/164
 
   # private static final byte[] SIG_DIRC = { 'D', 'I', 'R', 'C' };
   #

--- a/lib/xgit/dircache/dir_cache_entry.ex
+++ b/lib/xgit/dircache/dir_cache_entry.ex
@@ -128,7 +128,7 @@ defmodule Xgit.DirCache.DirCacheEntry do
   # /** In-core flag signaling that the entry should be considered as modified. */
   # private static final int UPDATE_NEEDED = 0x1;
 
-  # TO DO: Finish porting this module. https://github.com/elixir-git/xgit/issues/157
+  # TO DO: Finish porting this module. https://github.com/elixir-git/archived-jgit-port/issues/157
 
   # DirCacheEntry(final byte[] sharedInfo, final MutableInteger infoAt,
   #     final InputStream in, final MessageDigest md, final int smudge_s,

--- a/lib/xgit/lib/commit_builder.ex
+++ b/lib/xgit/lib/commit_builder.ex
@@ -62,7 +62,7 @@ defmodule Xgit.Lib.CommitBuilder do
   * encodings other than UTF-8
   * GPG signatures
 
-  https://github.com/elixir-git/xgit/issues/171
+  https://github.com/elixir-git/archived-jgit-port/issues/171
   """
 
   @typedoc ~S"""

--- a/lib/xgit/lib/config.ex
+++ b/lib/xgit/lib/config.ex
@@ -63,7 +63,7 @@ defmodule Xgit.Lib.Config do
   * include file support
   * a few edge cases
 
-  _TO DO:_ https://github.com/elixir-git/xgit/issues/129
+  _TO DO:_ https://github.com/elixir-git/archived-jgit-port/issues/129
 
   _PORTING NOTE:_ Xgit does not have explicit enum support, unlike jgit. There is very
   little about the various `ConfigEnum` implementations that is sharable, so it did
@@ -509,7 +509,7 @@ defmodule Xgit.Lib.Config do
     do: names ++ names_in_subsection(base_config, section, subsection, recursive?: true)
 
   # TO DO: Cache section parser results like Config.SectionParser in jgit?
-  # https://github.com/elixir-git/xgit/issues/183
+  # https://github.com/elixir-git/archived-jgit-port/issues/183
 
   # /**
   #  * Obtain a handle to a parsed set of configuration values.

--- a/lib/xgit/lib/constants.ex
+++ b/lib/xgit/lib/constants.ex
@@ -430,7 +430,7 @@ defmodule Xgit.Lib.Constants do
   @spec attr_built_in_binary_merger :: String.t()
   def attr_built_in_binary_merger, do: "binary"
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/130
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/130
   # /**
   #  * Create a new digest function for objects.
   #  *

--- a/lib/xgit/lib/object_database.ex
+++ b/lib/xgit/lib/object_database.ex
@@ -98,7 +98,7 @@ defmodule Xgit.Lib.ObjectDatabase do
 
   def valid?(_), do: false
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/132
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/132
 
   @doc ~S"""
   Returns `true` if this database exists.
@@ -138,7 +138,7 @@ defmodule Xgit.Lib.ObjectDatabase do
 
   Should return `{:ok, mod_state}` for function chaining or (TBD) if not.
 
-  _TO DO:_ Finalize error-handling strategy here. https://github.com/elixir-git/xgit/issues/132
+  _TO DO:_ Finalize error-handling strategy here. https://github.com/elixir-git/archived-jgit-port/issues/132
 
   ## Error
 

--- a/lib/xgit/lib/object_reader.ex
+++ b/lib/xgit/lib/object_reader.ex
@@ -51,7 +51,7 @@ defmodule Xgit.Lib.ObjectReader do
   Readers that can support efficient reuse of pack encoded objects should also
   implement the companion protocol `ObjectReuseAsIs` _(not yet ported)_.
 
-  TO DO: https://github.com/elixir-git/xgit/issues/133
+  TO DO: https://github.com/elixir-git/archived-jgit-port/issues/133
 
   PORTING NOTE: Is this necessarily tied to a single process in Elixir?
 

--- a/lib/xgit/lib/ref_database.ex
+++ b/lib/xgit/lib/ref_database.ex
@@ -87,7 +87,7 @@ defmodule Xgit.Lib.RefDatabase do
     end
   end
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/134
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/134
 
   # /**
   #  * Order of prefixes to search when using non-absolute references.

--- a/lib/xgit/lib/repository.ex
+++ b/lib/xgit/lib/repository.ex
@@ -67,7 +67,7 @@ defmodule Xgit.Lib.Repository do
 
   @type t :: pid
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/136
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/136
 
   # /**
   #  * Branch names containing slashes should not have a name component that is

--- a/lib/xgit/lib/repository_cache.ex
+++ b/lib/xgit/lib/repository_cache.ex
@@ -47,7 +47,7 @@
 defmodule Xgit.Lib.RepositoryCache do
   @moduledoc false
   # MOSTLY UNIMPLEMENTED FOR NOW
-  # TO DO: https://github.com/elixir-git/xgit/issues/135
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/135
   #
   # /**
   #  * Cache of active {@link org.eclipse.jgit.lib.Repository} instances.

--- a/lib/xgit/revwalk/rev_blob.ex
+++ b/lib/xgit/revwalk/rev_blob.ex
@@ -88,7 +88,7 @@ defmodule Xgit.RevWalk.RevBlob do
       do: %{object | flags: MapSet.difference(flags, new_flags)}
 
     # TO DO: Finish implementation of RevObject and related modules.
-    # https://github.com/elixir-git/xgit/issues/181
+    # https://github.com/elixir-git/archived-jgit-port/issues/181
 
     # @Override
     # void parseHeaders(RevWalk walk) throws MissingObjectException,

--- a/lib/xgit/revwalk/rev_object.ex
+++ b/lib/xgit/revwalk/rev_object.ex
@@ -152,7 +152,7 @@ defmodule Xgit.RevWalk.RevObject do
   end
 
   # TO DO: Finish implementation of RevObject and related modules.
-  # https://github.com/elixir-git/xgit/issues/181
+  # https://github.com/elixir-git/archived-jgit-port/issues/181
 
   # abstract void parseHeaders(RevWalk walk) throws MissingObjectException,
   #     IncorrectObjectTypeException, IOException;

--- a/lib/xgit/storage/file/file_based_config.ex
+++ b/lib/xgit/storage/file/file_based_config.ex
@@ -94,7 +94,7 @@ defmodule Xgit.Storage.File.FileBasedConfig do
       else: FileSnapshot.missing_file()
   end
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/137
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/137
 
   # /** {@inheritDoc} */
   # @Override

--- a/lib/xgit/storage/file/file_repository.ex
+++ b/lib/xgit/storage/file/file_repository.ex
@@ -157,7 +157,7 @@ defmodule Xgit.Storage.File.FileRepository do
       |> load_config()
 
     # TO DO: Shouldn't this fall back to user_config?
-    # https://github.com/elixir-git/xgit/issues/139
+    # https://github.com/elixir-git/archived-jgit-port/issues/139
 
     # repoConfig.addChangeListener(new ConfigChangedListener() {
     #   @Override
@@ -197,7 +197,7 @@ defmodule Xgit.Storage.File.FileRepository do
       ObjectDirectory.start_link(config: Config.new(), objects: object_dir)
 
     # TO DO: Pass additional options (repoConfig, alternateObjectDirectories, Constants.SHALLOW)
-    # through to ObjectDirectory. https://github.com/elixir-git/xgit/issues/139
+    # through to ObjectDirectory. https://github.com/elixir-git/archived-jgit-port/issues/139
 
     # objectDatabase = new ObjectDirectory(repoConfig, //
     #     options.getObjectDirectory(), //
@@ -255,7 +255,7 @@ defmodule Xgit.Storage.File.FileRepository do
   defp downcase_if_not_nil(nil), do: nil
   defp downcase_if_not_nil(s), do: String.downcase(s)
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/139
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/139
 
   # private static final String UNNAMED = "Unnamed repository; edit this file to name it for gitweb."; //$NON-NLS-1$
   #
@@ -308,7 +308,7 @@ defmodule Xgit.Storage.File.FileRepository do
     # RefUpdate code below. Porting RefUpdate draws in a few too many things just yet.
     File.write!(Path.join(git_dir, "HEAD"), "ref: refs/heads/master")
 
-    # TO DO: https://github.com/elixir-git/xgit/issues/139
+    # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/139
 
     # RefUpdate head = updateRef(Constants.HEAD);
     # head.disableRefLog();
@@ -404,7 +404,7 @@ defmodule Xgit.Storage.File.FileRepository do
     do: {:ok, repo_config, state}
 
   # TO DO: Should this call through to update_config?
-  # https://github.com/elixir-git/xgit/issues/139
+  # https://github.com/elixir-git/archived-jgit-port/issues/139
 
   # defp update_config(%{repo_config: repo_config}) do
   #   # TO DO: Port the part that updates the configs if needed.

--- a/lib/xgit/storage/file/file_repository_builder.ex
+++ b/lib/xgit/storage/file/file_repository_builder.ex
@@ -254,7 +254,7 @@ defmodule Xgit.Storage.File.FileRepositoryBuilder do
     |> setup_internals()
   end
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/138
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/138
 
   # /**
   #  * Create a repository matching the configuration in this builder.

--- a/lib/xgit/storage/file/internal/object_directory.ex
+++ b/lib/xgit/storage/file/internal/object_directory.ex
@@ -73,7 +73,7 @@ defmodule Xgit.Storage.File.Internal.ObjectDirectory do
 
   require Logger
 
-  # TO DO: Finish incomplete implementation: https://github.com/elixir-git/xgit/issues/126
+  # TO DO: Finish incomplete implementation: https://github.com/elixir-git/archived-jgit-port/issues/126
 
   # static enum InsertLooseObjectResult {
   #   INSERTED, EXISTS_PACKED, EXISTS_LOOSE, FAILURE;

--- a/lib/xgit/storage/file/internal/pack_index.ex
+++ b/lib/xgit/storage/file/internal/pack_index.ex
@@ -164,7 +164,7 @@ defmodule Xgit.Storage.File.Internal.PackIndex do
   defp toc?([0xFF, ?t, ?O, ?c | _]), do: true
   defp toc?(_), do: false
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/127
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/127
 
   # /**
   #  * Determine if an object is contained within the pack file.

--- a/lib/xgit/storage/file/internal/pack_index_v1.ex
+++ b/lib/xgit/storage/file/internal/pack_index_v1.ex
@@ -102,7 +102,7 @@ defmodule Xgit.Storage.File.Internal.PackIndexV1 do
     {IO.read(file_pid, bytes_to_read), item}
   end
 
-  # TO DO: Finish implementation of `resolve`: https://github.com/elixir-git/xgit/issues/127
+  # TO DO: Finish implementation of `resolve`: https://github.com/elixir-git/archived-jgit-port/issues/127
   # /** {@inheritDoc} */
   # @Override
   # public void resolve(Set<ObjectId> matches, AbbreviatedObjectId id,

--- a/lib/xgit/storage/file/internal/pack_index_v2.ex
+++ b/lib/xgit/storage/file/internal/pack_index_v2.ex
@@ -250,7 +250,7 @@ defmodule Xgit.Storage.File.Internal.PackIndexV2 do
     |> :erlang.list_to_binary()
   end
 
-  # TO DO: Finish implementation of `resolve`: https://github.com/elixir-git/xgit/issues/127
+  # TO DO: Finish implementation of `resolve`: https://github.com/elixir-git/archived-jgit-port/issues/127
   # public void resolve(Set<ObjectId> matches, AbbreviatedObjectId id,
   #     int matchLimit) throws IOException {
   #   int[] data = names[id.getFirstByte()];

--- a/lib/xgit/storage/file/internal/ref_directory.ex
+++ b/lib/xgit/storage/file/internal/ref_directory.ex
@@ -67,7 +67,7 @@ defmodule Xgit.Storage.File.Internal.RefDirectory do
 
   alias Xgit.Lib.Constants
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/128
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/128
 
   # /** Magic string denoting the start of a symbolic reference file. */
   # public static final String SYMREF = "ref: "; //$NON-NLS-1$

--- a/lib/xgit/storage/file/internal/window_cursor.ex
+++ b/lib/xgit/storage/file/internal/window_cursor.ex
@@ -57,7 +57,7 @@ defmodule Xgit.Storage.File.Internal.WindowCursor do
   defstruct [:db]
 
   # TO DO: Finish implementation of this module.
-  # https://github.com/elixir-git/xgit/issues/188
+  # https://github.com/elixir-git/archived-jgit-port/issues/188
 
   # /** Temporary buffer large enough for at least one raw object id. */
   # final byte[] tempId = new byte[Constants.OBJECT_ID_LENGTH];

--- a/lib/xgit/storage/file/internal/write_config.ex
+++ b/lib/xgit/storage/file/internal/write_config.ex
@@ -49,7 +49,7 @@ defmodule Xgit.Storage.File.Internal.WriteConfig do
   # INTERNAL: Parse some write configuration variables from config file.
 
   # TO DO: Cache section parser results like Config.SectionParser in jgit?
-  # https://github.com/elixir-git/xgit/issues/183
+  # https://github.com/elixir-git/archived-jgit-port/issues/183
 
   alias Xgit.Lib.Config
   alias Xgit.Lib.ConfigConstants

--- a/lib/xgit/util/compressed_bitmap.ex
+++ b/lib/xgit/util/compressed_bitmap.ex
@@ -47,7 +47,7 @@ defmodule Xgit.Util.CompressedBitmap do
   Hopefully eventually replaced with something as efficient
   as com.googlecode.javaewah.EWAHCompressedBitmap.
 
-  TO DO: https://github.com/elixir-git/xgit/issues/140
+  TO DO: https://github.com/elixir-git/archived-jgit-port/issues/140
 
   Unlike traditional `MapSet`, values must be non-negative integers.
 

--- a/lib/xgit/util/nb.ex
+++ b/lib/xgit/util/nb.ex
@@ -49,7 +49,7 @@ defmodule Xgit.Util.NB do
   Conversion utilities for network byte order handling.
   """
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/141
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/141
 
   use Bitwise
 

--- a/lib/xgit/util/raw_parse_utils.ex
+++ b/lib/xgit/util/raw_parse_utils.ex
@@ -68,7 +68,7 @@ defmodule Xgit.Util.RawParseUtils do
   def match_prefix?([c | b], [c | str]), do: match_prefix?(b, str)
   def match_prefix?(_, _), do: false
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/142
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/142
 
   # /**
   #  * Format a base 10 numeric into a temporary buffer.

--- a/lib/xgit/util/string_utils.ex
+++ b/lib/xgit/util/string_utils.ex
@@ -51,7 +51,7 @@ defmodule Xgit.Util.StringUtils do
   _PORTING NOTE:_ This jgit class is being ported on an as-needed basis.
   """
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/143
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/143
 
   # private static final char[] LC;
   #

--- a/lib/xgit/util/system_reader.ex
+++ b/lib/xgit/util/system_reader.ex
@@ -124,7 +124,7 @@ defprotocol Xgit.Util.SystemReader do
   @spec timezone(reader :: term) :: integer
   def timezone(reader \\ nil)
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/144
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/144
 
   # /**
   #  * Get the locale to use

--- a/test/support/local_disk_repository_test_case.ex
+++ b/test/support/local_disk_repository_test_case.ex
@@ -57,7 +57,7 @@ defmodule Xgit.Test.LocalDiskRepositoryTestCase do
   of test case classes in jgit. So, for now, I'm keeping this fairly minimal.
   """
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/145
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/145
 
   # /**
   #  * Callers should not use {@link org.eclipse.jgit.lib.RepositoryCache} from

--- a/test/support/pack_index_test_case.ex
+++ b/test/support/pack_index_test_case.ex
@@ -57,7 +57,7 @@ defmodule Xgit.Test.PackIndexTestCase do
     end
   end
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/146
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/146
 
   # /**
   #  * Test contracts of Iterator methods and this implementation remove()

--- a/test/support/repository_test_case.ex
+++ b/test/support/repository_test_case.ex
@@ -71,7 +71,7 @@ defmodule Xgit.Test.RepositoryTestCase do
     setup_test!()
   end
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/147
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/147
 
   # /**
   #  * Copy a file

--- a/test/support/test_repository.ex
+++ b/test/support/test_repository.ex
@@ -94,7 +94,7 @@ defmodule Xgit.Test.TestRepository do
   end
 
   # TO DO: Port the rest of this module.
-  # https://github.com/elixir-git/xgit/issues/179
+  # https://github.com/elixir-git/archived-jgit-port/issues/179
 
   # /**
   #  * Get date

--- a/test/xgit/lib/commit_builder_test.exs
+++ b/test/xgit/lib/commit_builder_test.exs
@@ -122,7 +122,7 @@ defmodule Xgit.Lib.CommitBuilderTest do
     end
   end
 
-  # TO DO: Add support for GPG signatures. https://github.com/elixir-git/xgit/issues/171
+  # TO DO: Add support for GPG signatures. https://github.com/elixir-git/archived-jgit-port/issues/171
 
   # private void assertGpgSignatureStringOutcome(String signature,
   #     String expectedOutcome) throws IOException {

--- a/test/xgit/lib/config_test.exs
+++ b/test/xgit/lib/config_test.exs
@@ -61,7 +61,7 @@ defmodule Xgit.Lib.ConfigTest do
   # A non-ASCII whitespace character: U+2002 EN QUAD.
   @ws "\u2002"
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/129
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/129
 
   # private static final String REFS_ORIGIN = "+refs/heads/*:refs/remotes/origin/*";
   #

--- a/test/xgit/storage/file/file_based_config_test.exs
+++ b/test/xgit/storage/file/file_based_config_test.exs
@@ -55,7 +55,7 @@ defmodule Xgit.Storage.File.FileBasedConfigTest do
   @user "user"
   @name "name"
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/148
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/148
 
   # private static final String EMAIL = "email";
 

--- a/test/xgit/storage/file/file_repository_builder_test.exs
+++ b/test/xgit/storage/file/file_repository_builder_test.exs
@@ -588,7 +588,7 @@ defmodule Xgit.Storage.File.FileRepositoryBuilderTest do
                     {%ArgumentError{message: "RefTreeDatabase not yet implemented"}, _}}
   end
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/138
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/138
 
   # @Test
   # public void absoluteGitDirRef() throws Exception {

--- a/test/xgit/storage/file/internal/pack_index_v1_test.exs
+++ b/test/xgit/storage/file/internal/pack_index_v1_test.exs
@@ -60,7 +60,7 @@ defmodule Xgit.Storage.File.Internal.PackIndexV1Test do
 
   # DISABLED: We don't actually have a dense V1 pack index file to work from.
   # See https://bugs.eclipse.org/bugs/show_bug.cgi?id=547201.
-  # TO DO: Create a dense V1 pack index file: https://github.com/elixir-git/xgit/issues/127
+  # TO DO: Create a dense V1 pack index file: https://github.com/elixir-git/archived-jgit-port/issues/127
 
   # defp path_for_pack_df2982f28 do
   #   # aka "dense index"
@@ -85,7 +85,7 @@ defmodule Xgit.Storage.File.Internal.PackIndexV1Test do
            ]
   end
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/127
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/127
 
   # DISABLED: We don't actually have a dense V1 pack index file to work from.
   # See https://bugs.eclipse.org/bugs/show_bug.cgi?id=547201.

--- a/test/xgit/support/test_repository_test.exs
+++ b/test/xgit/support/test_repository_test.exs
@@ -53,7 +53,7 @@ defmodule Xgit.Test.TestRepositoryTest do
   alias Xgit.Test.TestRepository
 
   # TO DO: Transition this to using InMemoryRepository when that's available.
-  # https://github.com/elixir-git/xgit/issues/174
+  # https://github.com/elixir-git/archived-jgit-port/issues/174
 
   setup do
     git_dir = LocalDiskRepositoryTestCase.create_work_repository!()

--- a/test/xgit/util/nb_test.exs
+++ b/test/xgit/util/nb_test.exs
@@ -49,7 +49,7 @@ defmodule Xgit.Util.NBTest do
 
   alias Xgit.Util.NB
 
-  # TO DO: https://github.com/elixir-git/xgit/issues/141
+  # TO DO: https://github.com/elixir-git/archived-jgit-port/issues/141
 
   # @Test
   # public void testCompareUInt32() {


### PR DESCRIPTION
Please see the new note at the top of the README.

The project continues, albeit in a new form.